### PR TITLE
feat: 마이레시피 조회 및 레시피 저장/수정 기능 구현

### DIFF
--- a/src/main/java/com/firstsnow/blockchef/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/firstsnow/blockchef/config/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.firstsnow.blockchef.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getSubject(token);
+
+            // 여기선 DB를 거치지 않고 간단한 UserDetails 생성 (프로젝트 상황에 따라 커스터마이징 가능)
+            User userDetails = new User(email, "", Collections.emptyList());
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            // SecurityContext에 인증 객체 등록
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        // 예: Authorization: Bearer eyJhbGciOiJIUzI1NiJ9...
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/firstsnow/blockchef/config/JwtTokenProvider.java
+++ b/src/main/java/com/firstsnow/blockchef/config/JwtTokenProvider.java
@@ -33,4 +33,25 @@ public class JwtTokenProvider {
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)   // 서명
                 .compact();  // 최종 JWT 문자열 반환
     }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String getSubject(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
 }

--- a/src/main/java/com/firstsnow/blockchef/config/SecurityConfig.java
+++ b/src/main/java/com/firstsnow/blockchef/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.firstsnow.blockchef.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,10 +8,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -29,9 +34,13 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
-                        .requestMatchers("/signup/**", "/login", "/**", "/api/**").permitAll()  // 공개 접근 허용 URL
+                        .requestMatchers(
+                                "/auth/**",
+                                "/api/public/**"
+                        ).permitAll()  // 공개 접근 허용 URL
                         .anyRequest().authenticated()  // 나머지 요청은 인증 필요
-                );
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/firstsnow/blockchef/controller/AuthController.java
+++ b/src/main/java/com/firstsnow/blockchef/controller/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
     @Operation(summary = "로그인", description = "로그인을 한다.")
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginRequest request) {
-        String token = loginService.login(request);
+        String token = loginService.login(request);  // JWT 생성
         return ResponseEntity.ok(token); // 토큰을 응답 본문으로 전달
     }
 

--- a/src/main/java/com/firstsnow/blockchef/controller/RecipeController.java
+++ b/src/main/java/com/firstsnow/blockchef/controller/RecipeController.java
@@ -1,0 +1,62 @@
+package com.firstsnow.blockchef.controller;
+
+
+import com.firstsnow.blockchef.dto.recipe.RecipeDetailResponse;
+import com.firstsnow.blockchef.dto.recipe.RecipeSummaryResponse;
+import com.firstsnow.blockchef.dto.recipe.RecipeUpsertRequest;
+import com.firstsnow.blockchef.service.RecipeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/recipes")
+@RequiredArgsConstructor
+@Tag(name = "레시피 관련", description = "레시피 저장, 조회, 수정, 삭제 기능")
+public class RecipeController {
+
+    private final RecipeService recipeService;
+
+    @Operation(summary = "레시피 저장 또는 수정", description = "ID가 없으면 새 레시피를 저장하고, 있으면 기존 레시피를 수정한다.")
+    @PutMapping
+    public ResponseEntity<String> upsertRecipe(@RequestBody @Valid RecipeUpsertRequest request,
+                                               @AuthenticationPrincipal UserDetails userDetails) {
+        String ownerEmail = userDetails.getUsername();
+        String recipeId = recipeService.upsertRecipe(request, ownerEmail);
+        return ResponseEntity.ok(recipeId);
+    }
+
+    @Operation(summary = "내 레시피 목록 조회", description = "로그인한 사용자의 모든 레시피 목록을 조회한다.")
+    @GetMapping("/my")
+    public ResponseEntity<List<RecipeSummaryResponse>> getMyRecipes(@AuthenticationPrincipal UserDetails userDetails) {
+        String ownerEmail = userDetails.getUsername();
+        List<RecipeSummaryResponse> recipes = recipeService.getMyRecipes(ownerEmail);
+        return ResponseEntity.ok(recipes);
+    }
+
+    @Operation(summary = "레시피 상세 조회", description = "레시피 ID로 상세 정보를 조회한다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<RecipeDetailResponse> getRecipeById(@PathVariable String id,
+                                                              @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        RecipeDetailResponse recipe = recipeService.getRecipeById(id, email);
+        return ResponseEntity.ok(recipe);
+    }
+
+    @Operation(summary = "레시피 삭제", description = "레시피 ID를 받아 해당 레시피를 삭제한다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteRecipe(@PathVariable String id,
+                                               @AuthenticationPrincipal UserDetails userDetails) {
+        recipeService.deleteRecipe(id, userDetails.getUsername());
+        return ResponseEntity.ok("레시피가 성공적으로 삭제되었습니다.");
+    }
+}
+
+

--- a/src/main/java/com/firstsnow/blockchef/controller/UserController.java
+++ b/src/main/java/com/firstsnow/blockchef/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.firstsnow.blockchef.controller;
+
+import com.firstsnow.blockchef.dto.user.MyInfoResponse;
+import com.firstsnow.blockchef.dto.user.MyInfoUpdateRequest;
+import com.firstsnow.blockchef.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Tag(name = "유저 관련", description = "내 정보 조회, 수정, 회원 탈퇴 기능")
+public class UserController {
+
+    private final UserService userService;
+
+    // ✅ 1. 내 정보 조회
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 이름, 이메일 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ResponseEntity<MyInfoResponse> getMyInfo(@AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        MyInfoResponse response = userService.getMyInfo(email);
+        return ResponseEntity.ok(response);
+    }
+
+    // ✅ 2. 내 정보 수정
+    @Operation(summary = "내 정보 수정", description = "이름 또는 비밀번호를 수정합니다. 비밀번호 변경 시에는 확인값도 필요합니다.")
+    @PutMapping("/me")
+    public ResponseEntity<String> updateMyInfo(@AuthenticationPrincipal UserDetails userDetails,
+                                               @RequestBody @Valid MyInfoUpdateRequest request) {
+        String email = userDetails.getUsername();
+        userService.updateMyInfo(email, request);
+        return ResponseEntity.ok("내 정보가 성공적으로 수정되었습니다.");
+    }
+
+    // ✅ 3. 회원 탈퇴
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
+    @DeleteMapping("/me")
+    public ResponseEntity<String> withdraw(@AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        userService.withdraw(email);
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/firstsnow/blockchef/domain/Recipe.java
+++ b/src/main/java/com/firstsnow/blockchef/domain/Recipe.java
@@ -1,0 +1,28 @@
+package com.firstsnow.blockchef.domain;
+
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Document(collection = "recipes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Recipe {
+
+    @Id
+    private String id;
+
+    private String title;
+    private String description;
+    private String ownerEmail;
+    private String blockStructure;
+    private List<String> tags;
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/firstsnow/blockchef/domain/User.java
+++ b/src/main/java/com/firstsnow/blockchef/domain/User.java
@@ -1,4 +1,4 @@
-package com.firstsnow.blockchef.domain.user;
+package com.firstsnow.blockchef.domain;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/firstsnow/blockchef/dto/recipe/RecipeDetailResponse.java
+++ b/src/main/java/com/firstsnow/blockchef/dto/recipe/RecipeDetailResponse.java
@@ -1,0 +1,43 @@
+package com.firstsnow.blockchef.dto.recipe;
+
+import com.firstsnow.blockchef.domain.Recipe;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RecipeDetailResponse {
+
+    @Schema(description = "레시피 ID", example = "64b8fda1234567")
+    private String id;
+
+    @Schema(description = "레시피 제목", example = "얼큰 감자 스튜")
+    private String title;
+
+    @Schema(description = "레시피 설명", example = "매운 맛이 도는 감자 베이스 스튜입니다.")
+    private String description;
+
+    @Schema(description = "블록 구조 (Blockly JSON)", example = "{...}")
+    private String blockStructure;
+
+    @Schema(description = "태그 목록", example = "[\"매운맛\", \"스튜\", \"감자\"]")
+    private List<String> tags;
+
+    @Schema(description = "수정된 시간", example = "2025-07-23T10:25:00")
+    private LocalDateTime updatedAt;
+
+    public static RecipeDetailResponse from(Recipe recipe) {
+        return new RecipeDetailResponse(
+                recipe.getId(),
+                recipe.getTitle(),
+                recipe.getDescription(),
+                recipe.getBlockStructure(),
+                recipe.getTags(),
+                recipe.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/firstsnow/blockchef/dto/recipe/RecipeSummaryResponse.java
+++ b/src/main/java/com/firstsnow/blockchef/dto/recipe/RecipeSummaryResponse.java
@@ -1,0 +1,41 @@
+package com.firstsnow.blockchef.dto.recipe;
+
+
+import com.firstsnow.blockchef.domain.Recipe;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RecipeSummaryResponse {
+
+    @Schema(description = "레시피 ID", example = "64b8fda1234567")
+    private String id;
+
+    @Schema(description = "레시피 제목", example = "얼큰 감자 스튜")
+    private String title;
+
+    @Schema(description = "레시피 설명", example = "매운 맛이 도는 감자 베이스 스튜입니다.")
+    private String description;
+
+    @Schema(description = "태그 목록", example = "[\"매운맛\", \"스튜\", \"감자\"]")
+    private List<String> tags;
+
+    @Schema(description = "수정된 시간", example = "2025-07-23T10:25:00")
+    private LocalDateTime updatedAt;
+
+    public static RecipeSummaryResponse from(Recipe recipe) {
+        return new RecipeSummaryResponse(
+                recipe.getId(),
+                recipe.getTitle(),
+                recipe.getDescription(),
+                recipe.getTags(),
+                recipe.getUpdatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/firstsnow/blockchef/dto/recipe/RecipeUpsertRequest.java
+++ b/src/main/java/com/firstsnow/blockchef/dto/recipe/RecipeUpsertRequest.java
@@ -1,0 +1,28 @@
+package com.firstsnow.blockchef.dto.recipe;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RecipeUpsertRequest {
+
+    @Schema(description = "레시피 ID (수정 시 필요, 신규 생성 시 null)", example = "64b8fda1234567")
+    private String id;
+
+    @Schema(description = "레시피 제목", example = "얼큰 감자 스튜")
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @Schema(description = "레시피 설명", example = "매운 맛이 도는 감자 베이스 스튜입니다.")
+    private String description;
+
+    @Schema(description = "블록 구조 (Blockly JSON)", example = "{...}")
+    @NotBlank(message = "블록 구조는 필수입니다.")
+    private String blockStructure;
+
+    @Schema(description = "태그 목록", example = "[\"매운맛\", \"스튜\", \"감자\"]")
+    private List<String> tags;
+}

--- a/src/main/java/com/firstsnow/blockchef/dto/user/MyInfoResponse.java
+++ b/src/main/java/com/firstsnow/blockchef/dto/user/MyInfoResponse.java
@@ -1,0 +1,19 @@
+package com.firstsnow.blockchef.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "내 정보 조회 응답")
+public class MyInfoResponse {
+
+    @Schema(description = "사용자의 이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "사용자의 이메일", example = "hong@blockchef.store")
+    private String email;
+}

--- a/src/main/java/com/firstsnow/blockchef/dto/user/MyInfoUpdateRequest.java
+++ b/src/main/java/com/firstsnow/blockchef/dto/user/MyInfoUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.firstsnow.blockchef.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "내 정보 수정 요청")
+public class MyInfoUpdateRequest {
+
+    @Schema(description = "변경할 이름", example = "김도엽")
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
+    @Schema(description = "변경할 비밀번호 (선택)", example = "newPassword123!")
+    private String password;
+
+    @Schema(description = "비밀번호 확인 (선택)", example = "newPassword123!")
+    private String passwordCheck;
+}

--- a/src/main/java/com/firstsnow/blockchef/exception/ApplicationError.java
+++ b/src/main/java/com/firstsnow/blockchef/exception/ApplicationError.java
@@ -22,7 +22,14 @@ public enum ApplicationError {
     // 로그인
     LOGIN_EMAIL_NOT_FOUND(HttpStatus.UNAUTHORIZED, "이메일이 존재하지 않습니다."),
     LOGIN_PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    USER_NOT_FOUND_BY_EMAIL(HttpStatus.NOT_FOUND, "해당 이메일로 가입된 사용자가 없습니다.");
+    USER_NOT_FOUND_BY_EMAIL(HttpStatus.NOT_FOUND, "해당 이메일로 가입된 사용자가 없습니다."),
+
+    // recipe 관련
+    RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "레시피를 찾을 수 없습니다."),
+    RECIPE_NO_PERMISSION(HttpStatus.FORBIDDEN, "레시피에 대한 권한이 없습니다.");
+
+
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/firstsnow/blockchef/repository/RecipeRepository.java
+++ b/src/main/java/com/firstsnow/blockchef/repository/RecipeRepository.java
@@ -1,0 +1,13 @@
+package com.firstsnow.blockchef.repository;
+
+import com.firstsnow.blockchef.domain.Recipe;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RecipeRepository extends MongoRepository<Recipe, String> {
+
+    List<Recipe> findByOwnerEmail(String ownerEmail);
+}

--- a/src/main/java/com/firstsnow/blockchef/repository/UserRepository.java
+++ b/src/main/java/com/firstsnow/blockchef/repository/UserRepository.java
@@ -1,6 +1,6 @@
 package com.firstsnow.blockchef.repository;
 
-import com.firstsnow.blockchef.domain.user.User;
+import com.firstsnow.blockchef.domain.User;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;

--- a/src/main/java/com/firstsnow/blockchef/service/LoginService.java
+++ b/src/main/java/com/firstsnow/blockchef/service/LoginService.java
@@ -1,7 +1,7 @@
 package com.firstsnow.blockchef.service;
 
 import com.firstsnow.blockchef.config.JwtTokenProvider;
-import com.firstsnow.blockchef.domain.user.User;
+import com.firstsnow.blockchef.domain.User;
 import com.firstsnow.blockchef.dto.login.LoginRequest;
 import com.firstsnow.blockchef.exception.ApplicationError;
 import com.firstsnow.blockchef.exception.ApplicationException;

--- a/src/main/java/com/firstsnow/blockchef/service/RecipeService.java
+++ b/src/main/java/com/firstsnow/blockchef/service/RecipeService.java
@@ -1,0 +1,87 @@
+package com.firstsnow.blockchef.service;
+
+import com.firstsnow.blockchef.domain.Recipe;
+import com.firstsnow.blockchef.dto.recipe.RecipeDetailResponse;
+import com.firstsnow.blockchef.dto.recipe.RecipeSummaryResponse;
+import com.firstsnow.blockchef.dto.recipe.RecipeUpsertRequest;
+import com.firstsnow.blockchef.exception.ApplicationError;
+import com.firstsnow.blockchef.exception.ApplicationException;
+import com.firstsnow.blockchef.repository.RecipeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecipeService {
+
+    private final RecipeRepository recipeRepository;
+
+    public String upsertRecipe(RecipeUpsertRequest request, String ownerEmail) {
+        // 새 레시피 저장
+        if (request.getId() == null || request.getId().isBlank()) {
+            Recipe newRecipe = Recipe.builder()
+                    .title(request.getTitle())
+                    .description(request.getDescription())
+                    .blockStructure(request.getBlockStructure())
+                    .tags(request.getTags())
+                    .ownerEmail(ownerEmail)
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            return recipeRepository.save(newRecipe).getId();
+        }
+
+        // 기존 레시피 수정
+        Recipe existing = recipeRepository.findById(request.getId())
+                .orElseThrow(() -> new ApplicationException(ApplicationError.RECIPE_NOT_FOUND));
+
+        if (!existing.getOwnerEmail().equalsIgnoreCase(ownerEmail)) {
+            throw new ApplicationException(ApplicationError.RECIPE_NO_PERMISSION);
+        }
+
+        Recipe updated = Recipe.builder()
+                .id(existing.getId())
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .blockStructure(request.getBlockStructure())
+                .tags(request.getTags())
+                .ownerEmail(existing.getOwnerEmail()) // 안전하게 보존
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return recipeRepository.save(updated).getId();
+    }
+
+    public List<RecipeSummaryResponse> getMyRecipes(String ownerEmail) {
+        List<Recipe> recipes = recipeRepository.findByOwnerEmail(ownerEmail);
+        return recipes.stream()
+                .map(RecipeSummaryResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public RecipeDetailResponse getRecipeById(String id, String currentUserEmail) {
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ApplicationError.RECIPE_NOT_FOUND));
+
+        if (!recipe.getOwnerEmail().equalsIgnoreCase(currentUserEmail)) {
+            throw new ApplicationException(ApplicationError.RECIPE_NO_PERMISSION);
+        }
+
+        return RecipeDetailResponse.from(recipe);
+    }
+
+    public void deleteRecipe(String id, String currentUserEmail) {
+        Recipe recipe = recipeRepository.findById(id)
+                .orElseThrow(() -> new ApplicationException(ApplicationError.RECIPE_NOT_FOUND));
+
+        if (!recipe.getOwnerEmail().equalsIgnoreCase(currentUserEmail)) {
+            throw new ApplicationException(ApplicationError.RECIPE_NO_PERMISSION);
+        }
+
+        recipeRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/firstsnow/blockchef/service/UserService.java
+++ b/src/main/java/com/firstsnow/blockchef/service/UserService.java
@@ -1,12 +1,15 @@
 package com.firstsnow.blockchef.service;
 
-import com.firstsnow.blockchef.domain.user.User;
+import com.firstsnow.blockchef.domain.User;
 import com.firstsnow.blockchef.dto.passwordchange.PasswordChangeRequest;
 import com.firstsnow.blockchef.dto.signup.SignupRequest;
+import com.firstsnow.blockchef.dto.user.MyInfoResponse;
+import com.firstsnow.blockchef.dto.user.MyInfoUpdateRequest;
 import com.firstsnow.blockchef.exception.ApplicationError;
 import com.firstsnow.blockchef.exception.ApplicationException;
 import com.firstsnow.blockchef.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,4 +62,42 @@ public class UserService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         userRepository.save(user);
     }
+
+    // 내 정보 조회
+    @Transactional
+    public MyInfoResponse getMyInfo(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        return new MyInfoResponse(user.getName(), user.getEmail());
+    }
+
+
+    // 내 정보 수정
+    @Transactional
+    public void updateMyInfo(String email, MyInfoUpdateRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        user.setName(request.getName());
+
+        if (request.getPassword() != null && !request.getPassword().isBlank()) {
+            if (!request.getPassword().equals(request.getPasswordCheck())) {
+                throw new ApplicationException(ApplicationError.PASSWORD_MISMATCH); // 직접 정의한 예외 사용
+            }
+            user.setPassword(passwordEncoder.encode(request.getPassword()));
+        }
+
+        userRepository.save(user); // 변경 감지로 자동 반영되지만 명시적으로 저장
+    }
+
+
+    // 회원 탈퇴
+    public void withdraw(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        userRepository.delete(user); // 하드 삭제 방식
+    }
+
 }


### PR DESCRIPTION
- RecipeUpsertRequest, RecipeSummaryResponse, RecipeDetailResponse DTO 정의
- 레시피 저장 및 수정 통합 (upsert) 로직 구현
- 마이레시피 목록 조회 및 단건 조회 API 추가
- 레시피 삭제 기능 구현
- @AuthenticationPrincipal 기반 사용자 인증 정보 처리 적용
- Swagger 설정을 고려한 controller, dto 리팩토링
- 예외 상황에서 500 응답 처리 확인